### PR TITLE
Модификатор type=global для блока b-text

### DIFF
--- a/blocks-desktop/b-text/_type/b-text_type_global.css
+++ b/blocks-desktop/b-text/_type/b-text_type_global.css
@@ -56,12 +56,12 @@
         padding: 0;
     }
 
-    .b-text_type_global ol .b-text_type_global li
+    .b-text_type_global ol li
     {
         list-style: decimal;
     }
 
-    .b-text_type_global ul .b-text_type_global li
+    .b-text_type_global ul li
     {
         list-style: disc;
     }

--- a/blocks-desktop/b-text/_type/b-text_type_global.css
+++ b/blocks-desktop/b-text/_type/b-text_type_global.css
@@ -1,0 +1,67 @@
+    .b-text_type_global h1,
+    .b-text_type_global h2,
+    .b-text_type_global h3
+    {
+        font-size: 1.8em;
+        font-weight: normal;
+
+        margin: 1.5em 0 0.7em 0;
+        padding: 0;
+    }
+
+    .b-text_type_global h3
+    {
+        font-size: 1.6em;
+
+        margin: 1em 0 0.5em 0;
+    }
+
+    .b-text_type_global h4
+    {
+        font-size: 1.4em;
+        font-weight: 400;
+
+        margin: 0.6em 0 0.5em 0;
+        padding: 0;
+    }
+
+    .b-text_type_global p
+    {
+        margin: 0 0 0.8em;
+
+        line-height: 1.4em;
+    }
+
+    .b-text_type_global pre,
+    .b-text_type_global tt
+    {
+        font: 100% Monaco, Consolas, "Courier New", monospace;
+    }
+
+    .b-text_type_global pre
+    {
+        margin: 0 0 0.8em;
+    }
+
+    .b-text_type_global ul,
+    .b-text_type_global ol
+    {
+        margin: 0 0 1em;
+        padding: 0;
+    }
+
+    .b-text_type_global li
+    {
+        margin: 0 0.2em 0.3em 2.5em;
+        padding: 0;
+    }
+
+    .b-text_type_global ol .b-text_type_global li
+    {
+        list-style: decimal;
+    }
+
+    .b-text_type_global ul .b-text_type_global li
+    {
+        list-style: disc;
+    }


### PR DESCRIPTION
возможно, есть смысл отказаться от БЕМ подхода в блоке b-text, причины:
- на реальном сайте в 99% случаев будет визивиг, он генерирует совсем другой код
- на данным момент не существует плагина, позволяющего с помощью визивига генерировать код, дружелюбный для b-text
- в нынешнем виде у блока b-text мало шансов для внедрения на реальных сайтах
