### PR TITLE
"class" is reserved word in javascript

### DIFF
--- a/blocks-desktop/b-page/b-page.bemhtml
+++ b/blocks-desktop/b-page/b-page.bemhtml
@@ -5,7 +5,7 @@ block b-page {
             this._mode = '',
             this.ctx = {
                 tag: 'html',
-                attrs : { class: 'i-ua_js_no i-ua_css_standard'},
+                cls: 'i-ua_js_no i-ua_css_standard',
                 content: [
                     {
                         elem: 'head',


### PR DESCRIPTION
Using `cls` mode insted of `atts: { class: '...' }` is more bemhtml-like
