### PR TITLE
Passing event data to callback of liveInitOnBlockEvent

### DIFF
--- a/blocks-common/i-bem/__dom/i-bem__dom.js
+++ b/blocks-common/i-bem/__dom/i-bem__dom.js
@@ -1281,7 +1281,7 @@ var DOM = BEM.DOM = BEM.decl('i-bem__dom',/** @lends BEM.DOM.prototype */{
         blocks[blockName].on(event, function(e) {
             var blocks = e.block[findFnName](name);
             callback && blocks.forEach(function(block) {
-                callback.call(block);
+                callback.call(block, e);
             });
         });
         return this;


### PR DESCRIPTION
Если подписаться на события блоков через лив-инициализацию, используя методы liveInitOnBlockEvent или liveInitOnBlockInsideEvent, то в функцию-коллбек приходит только контекст текущего блока и никаких аргументов. Таким образом, невозможно узнать, на каком именно блоке произошло событие.
Исправил проблему.
