### PR TITLE
Исправление некорректного js-условия

### DIFF
--- a/blocks-desktop/b-layout-table/b-layout-table.bemhtml
+++ b/blocks-desktop/b-layout-table/b-layout-table.bemhtml
@@ -4,7 +4,7 @@ block b-layout-table {
 
     elem row, tag: 'tr'
 
-    this.elem === 'cell' || this.elem === 'gap' {
+    (this.elem === 'cell' || this.elem === 'gap') {
         tag: 'td'
         attrs: {
 


### PR DESCRIPTION
Конструкция вида `this.elem === 'cell' || this.elem === 'gap'` компилируется в выражение вида `if(!(this.block === "b-layout-table" && this.elem === "cell" || this.elem === "gap" && this._mode === "tag") === false) {return "td";return}` которое срабатывает для всех элементов `gap`.
