### PR TITLE
Не выводить "ложные" значения в контент

### DIFF
--- a/blocks-common/i-bem/__html/i-bem__html.bemhtml
+++ b/blocks-common/i-bem/__html/i-bem__html.bemhtml
@@ -50,7 +50,7 @@
 
     this._.isSimple(this.ctx): {
         this._listLength--;
-        this._buf.push(this.ctx)
+        (this.ctx || this.ctx === 0) && this._buf.push(this.ctx)
     }
 
 }


### PR DESCRIPTION
```
{
  block: 'bla',
  content: [
    false,
    true,
    0,
    ''
  ]
}
```

Должен вывести:

```
<div>true0</div>
```
