### PR TITLE
Поправил метод toggleMod

### DIFF
--- a/blocks-common/i-bem/i-bem.js
+++ b/blocks-common/i-bem/i-bem.js
@@ -394,14 +394,21 @@ this.BEM = $.inherit($.observable, /** @lends BEM.prototype */ {
             modVal2 = '';
         }
 
-        var modVal = this.getMod(elem, modName);
-        (modVal == modVal1 || modVal == modVal2) &&
-            this.setMod(
-                elem,
-                modName,
-                typeof condition === 'boolean'?
-                    (condition? modVal1 : modVal2) :
-                    this.hasMod(elem, modName, modVal1)? modVal2 : modVal1);
+        var _this = this;
+        $.each(elem, function(index, elem) {
+
+            elem = $(elem);
+
+            var modVal = _this.getMod(elem, modName);
+            (modVal == modVal1 || modVal == modVal2) &&
+                _this.setMod(
+                    elem,
+                    modName,
+                    typeof condition === 'boolean'?
+                        (condition? modVal1 : modVal2) :
+                        _this.hasMod(elem, modName, modVal1)? modVal2 : modVal1);
+
+        });
 
         return this;
 

--- a/blocks-common/i-bem/i-bem.js
+++ b/blocks-common/i-bem/i-bem.js
@@ -385,7 +385,7 @@ this.BEM = $.inherit($.observable, /** @lends BEM.prototype */ {
             modVal2 = modVal1;
             modVal1 = modName;
             modName = elem;
-            elem = [undefined];
+            elem = undefined;
         }
         if(typeof modVal2 == 'undefined') {
             modVal2 = '';
@@ -395,8 +395,8 @@ this.BEM = $.inherit($.observable, /** @lends BEM.prototype */ {
         }
 
         var _this = this;
-        $.each(elem, function(index, elem) {
-            elem = elem && $(elem);
+        $.each(elem || [undefined], function(index, elem) {
+            elem = elem && $(elem); // Если это элемент
             var modVal = _this.getMod(elem, modName);
             (modVal == modVal1 || modVal == modVal2) &&
                 _this.setMod(

--- a/blocks-common/i-bem/i-bem.js
+++ b/blocks-common/i-bem/i-bem.js
@@ -385,7 +385,7 @@ this.BEM = $.inherit($.observable, /** @lends BEM.prototype */ {
             modVal2 = modVal1;
             modVal1 = modName;
             modName = elem;
-            elem = undefined;
+            elem = [undefined];
         }
         if(typeof modVal2 == 'undefined') {
             modVal2 = '';
@@ -396,9 +396,7 @@ this.BEM = $.inherit($.observable, /** @lends BEM.prototype */ {
 
         var _this = this;
         $.each(elem, function(index, elem) {
-
-            elem = $(elem);
-
+            elem = elem && $(elem);
             var modVal = _this.getMod(elem, modName);
             (modVal == modVal1 || modVal == modVal2) &&
                 _this.setMod(
@@ -407,7 +405,6 @@ this.BEM = $.inherit($.observable, /** @lends BEM.prototype */ {
                     typeof condition === 'boolean'?
                         (condition? modVal1 : modVal2) :
                         _this.hasMod(elem, modName, modVal1)? modVal2 : modVal1);
-
         });
 
         return this;


### PR DESCRIPTION
Пример:

``` javascript
{
    block: 'b-list',
    content: [
        {
            elem: 'item',
            content: 'Item #1'
        },
        {
            elem: 'item',
            elemMods: { hidden: 'yes' },
            content: 'Item #2'
        },
    ]
}
```

Сейчас, если сделать: 

``` javascript
this.toggleMod(this.elem('item'), 'hidden', 'yes')
```

  — у обоих элементов установится модификатор _hidden_yes.
