### PR TITLE
[touch] i-ua: Не работает проверка на wp для Windows Phone 8

### DIFF
--- a/blocks-touch/i-ua/i-ua.js
+++ b/blocks-touch/i-ua/i-ua.js
@@ -20,7 +20,7 @@
         device.ipad = true;
     } else if (match = ua.match(/Bada\/([\d.]+)/)) {
         platform.bada = match[1];
-    } else if (match = ua.match(/Windows\sPhone\sOS\s([\d.]+)/)) {
+    } else if (match = ua.match(/Windows\sPhone.*\s([\d.]+)/)) {
         platform.wp = match[1];
     } else {
         platform.other = true;


### PR DESCRIPTION
для wp8 не срабатывает регулярка, потому что в юзерагенте нет "OS"

Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; ARM; Touch; IEMobile/10.0; <Manufacturer>; <Device> [;<Operator>])

Для wp7 юзерагент такой

Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; SAMSUNG; SGH-i917)
