### PR TITLE
В IE10 не работают условные комментарии

### DIFF
--- a/blocks-touch/b-page/b-page.bemhtml
+++ b/blocks-touch/b-page/b-page.bemhtml
@@ -127,9 +127,7 @@ block b-page {
                     _mode: '',
                     _notIE: true,
                     ctx: [
-                        '<!--[if !IE]><!-->',
-                        this.ctx,
-                        '<!--<![endif]-->'
+                        this.ctx
                     ]
                 })
             },


### PR DESCRIPTION
Сейчас стили подключаются таким образом, что на выходе мы получаем

[if !IE] <link rel="stylesheet" href="_search.css"/><![endif]
[if gte IE 9]<link rel="stylesheet" href="_search.ie.css"/><![endif]

получается, что никакие страничные стили в этом браузере не подключаются
