### PR TITLE
Fixed issue with one-letter elements names

### DIFF
--- a/blocks-common/i-bem/__dom/i-bem__dom.js
+++ b/blocks-common/i-bem/__dom/i-bem__dom.js
@@ -1266,7 +1266,7 @@ var DOM = BEM.DOM = BEM.decl('i-bem__dom',/** @lends BEM.DOM.prototype */{
 
         var _this = this;
 
-        if(to.elem && to.elem.indexOf(' ') > 1) {
+        if(to.elem && to.elem.indexOf(' ') > 0) {
             to.elem.split(' ').forEach(function(elem) {
                 _this._liveClassBind(
                     buildClass(_this._name, elem, to.modName, to.modVal),


### PR DESCRIPTION
``` javascript
this.liveBindTo('a b c', 'event', function(){
     console.log(1);//will never run
})
```
