### PR TITLE
b-slider: добавлено событие transitionend для ie и firefox

### DIFF
--- a/blocks-touch/b-slider/b-slider.js
+++ b/blocks-touch/b-slider/b-slider.js
@@ -520,7 +520,7 @@
             slider.trigger('start', slider._getCurrentParams());
 
             slider._elem
-                .one(this.namespaced('webkitTransitionEnd oTransitionEnd otransitionend'),
+                .one(this.namespaced('webkitTransitionEnd oTransitionEnd otransitionend transitionend'),
                     function() {
                         slider.trigger('end', slider._getCurrentParams());
                     }


### PR DESCRIPTION
Не отрабатывается собитие end для блока b-slider в Windows Phone, потому что событие transitionend (используемое в ie) не было в списке подписок.
Этот патч это исправляет
