### PR TITLE
Перенес рассчет смещения начального элемента на момент после рассчета необходимости инициализировать слайдер

### DIFF
--- a/blocks-touch/b-slider/b-slider.js
+++ b/blocks-touch/b-slider/b-slider.js
@@ -147,20 +147,24 @@
                     slider._items.width(slider._elem.parent().width());
                 });
 
-                // коррекция начального смещения при непервом начальном элементе в поэкранном слайдере
-                if (slider._index) {
-                    slider._correctPerScreenNonFirst();
-                }
-            // если обычный слайдер
-            } else {
-                // коррекция начального смещения при непервом начальном элементе в обычном слайдере
-                if (slider._index) {
-                    slider._correctPerStepNonFirst();
-                }
             }
 
             // если есть куда и что слайдить
             if (slider._width > slider._parentWidth) {
+
+                // если начальный элемент не первый
+                if (slider._index) {
+
+                    // если полноэкранный слайдер
+                    if (slider._perScreen) {
+                        // коррекция начального смещения при непервом начальном элементе в поэкранном слайдере
+                        slider._correctPerScreenNonFirst();
+                    } else {
+                        // коррекция начального смещения при непервом начальном элементе в обычном слайдере
+                        slider._correctPerStepNonFirst();
+                    }
+
+                }
 
                 slider
                     // бинд на pointer-события


### PR DESCRIPTION
Сейчас, если указан параметр index, то слайдер смещается к элементу с этим номером, даже если ширина слайдера меньше чем ширина контейнера. В этом случае слайдер не работает, но элементы оказываются смещены и их никак нельзя "достать" из-за границы контейнера. Я перенес рассчет смещения на момент после проверки необходимости инициализировать слайдер. Таким образом, смещение не проихсодит, если слайдер итак полностью умещается в контейнер
