### PR TITLE
Синтаксическия ошибка в "i-ua_css_standard"

### DIFF
--- a/blocks-desktop/b-page/b-page.bemhtml
+++ b/blocks-desktop/b-page/b-page.bemhtml
@@ -55,7 +55,7 @@ block b-page {
 
         bem: false
         tag: 'html'
-        cls: 'i-ua_js_no i-ua_css_standard'
+        cls: 'i-ua_js_no i-ua_css_standart'
 
     }
 

--- a/blocks-touch/b-page/b-page.bemhtml
+++ b/blocks-touch/b-page/b-page.bemhtml
@@ -62,7 +62,7 @@ block b-page {
     elem root {
         bem: false
         tag: 'html'
-        cls: 'i-ua_js_no i-ua_css_standard'
+        cls: 'i-ua_js_no i-ua_css_standart'
     }
 
     elem head {


### PR DESCRIPTION
Везде, кроме blocks-desktop и blocks-touch, используется "i-ua_css_standart".
Привёл к общему виду.
