### PR TITLE
I18n.js

### DIFF
--- a/blocks-common/i-bem/__i18n/lib/i18n-js.js
+++ b/blocks-common/i-bem/__i18n/lib/i18n-js.js
@@ -1,4 +1,5 @@
 var TANKER = require('./tanker');
+var BEM = require('bem');
 
 exports.serializeAllData = function(data, langs, defaultLang) {
 
@@ -12,34 +13,61 @@ exports.serializeAllData = function(data, langs, defaultLang) {
 };
 
 exports.serializeData = function(data, lang) {
-
     var res = [];
+    var KEYS = (process.env.BEM_I18N_KEYS || []);
 
     Object.keys(data).sort().forEach(function(keyset) {
-
+        var keysetData = data[keyset];
         // output value of empty keyset as a simple js code
         if (keyset === '') {
-            res.push(data[keyset]);
+            res.push(keysetData);
             return;
-        }
+        };
 
-        // generate i18n declaration for normal keysets
-        res.push("\nBEM.I18N.decl('" + keyset + "', {");
-
-        Object.keys(data[keyset]).forEach(function(key, i, arr) {
-
-            TANKER.xmlToJs(data[keyset][key], function(js) {
-                res.push(JSON.stringify(key) + ': ' + js + (i === arr.length - 1 ? '' : ','));
-            });
-
-        });
-
-        res.push('}, {\n"lang": "' + lang + '"\n});\n');
+        getDecl(keysetData, keyset, { lang: lang }, res);
 
     });
 
     return res;
 
+    function getDecl (data, keyset, declKeys, res) {
+        var decl = [];
+
+        Object.keys(data).sort(function (a, b) {
+            // objects go first
+            if (typeof data[a] === 'object')
+                return -1;
+            return 1;
+        }).forEach(function (key, i, arr) {
+            var keyData = data[key];
+
+            console.log('typeof', typeof keyData, keyData);
+            if (typeof keyData === 'object') {
+                // BEM_I18N_KEYS
+                if (~KEYS.indexOf(key)) {
+                    Object.keys(keyData).sort().forEach(function (k) {
+                        // keyData[k] should be object
+                        if (typeof keyData[k] !== 'object')
+                            return;
+                        var extDeclKeys = BEM.util.extend(true, {}, declKeys);
+                        extDeclKeys[key] = k;
+                        getDecl(keyData[k], keyset, extDeclKeys, res);
+                    });
+                };
+            } else {
+                TANKER.xmlToJs(data[key], function(js) {
+                    decl.push(JSON.stringify(key) + ': ' + js + (i === arr.length - 1 ? '' : ','));
+                });
+            };
+        });
+
+        decl.unshift("\nBEM.I18N.decl('" + keyset + "', {");
+        decl.push('}, ');
+        decl.push(JSON.stringify(declKeys));
+        decl.push(');\n');
+
+        res = res.push(decl.join(''));
+    };
 };
 
 exports.serializeInit = function(lang) {

--- a/blocks-common/i-bem/__i18n/test/test-i18n-base.js
+++ b/blocks-common/i-bem/__i18n/test/test-i18n-base.js
@@ -88,3 +88,84 @@ suite('BEM.I18N Simple test', function() {
     });
 
 });
+
+suite('BEM.I18N._i18n public functions', function () {
+
+    test('setDeclProp', function () {
+        BEM.I18N._i18n.setDeclProp('lang', 'ru')
+        assert.equal('ru', BEM.I18N._i18n._declProps['lang']);
+
+        BEM.I18N._i18n.setDeclProp('lang', 'kz')
+        assert.equal('kz', BEM.I18N._i18n._declProps['lang']);
+
+        // deleting
+        BEM.I18N._i18n.setDeclProp('lang')
+        assert.equal(undefined, BEM.I18N._i18n._declProps['lang']);
+    });
+
+});
+
+suite('BEM.I18N multiple props', function () {
+
+    setup(function() {
+        BEM.I18N.brand = (function () {
+            var klass = function (brand) {
+                return BEM.I18N.setDeclProp('brand', brand, true);
+            };
+
+            return klass;
+        }) ();
+
+        BEM.I18N.lang('ru');
+        BEM.I18N.setOrderProps('lang', 'brand', 'version')
+
+        BEM.I18N.decl('i-keyset-0', {
+
+            "key1" : "Ключ1",
+            "key2" : "Ключ2"
+
+        }, { "lang" : "ru" });
+
+        BEM.I18N.decl('i-keyset-0', {
+
+            "key1" : "Ключ1-БрендированиеUA"
+
+        }, { "lang" : "ru", "brand" : "ua" });
+
+        BEM.I18N.decl('i-keyset-0', {
+
+            "key1" : "Ключ1-БрендированиеTR",
+            "key2" : "Ключ2-БрендированиеTR"
+
+        }, { "lang" : "ru", "brand" : "tr" });
+
+        BEM.I18N.decl('i-keyset-0', {
+
+            "key1" : "Ключ1-БрендированиеTR-Версия1",
+            "key3" : "Ключ3"
+
+        }, { "lang" : "ru", "brand" : "tr", "version" : "1.0" });
+
+    });
+
+    test('Simple', function () {
+        BEM.I18N._i18n.setDeclProp('brand', 'ua');
+
+        assert.equal('Ключ1-БрендированиеUA', BEM.I18N('i-keyset-0', 'key1'));
+        assert.equal('Ключ2', BEM.I18N('i-keyset-0', 'key2'));
+
+        BEM.I18N._i18n.setDeclProp('version', '1.0');
+
+        assert.equal('Ключ1-БрендированиеUA', BEM.I18N('i-keyset-0', 'key1'));
+
+        BEM.I18N.brand('tr');
+        assert.equal('Ключ1-БрендированиеTR-Версия1', BEM.I18N('i-keyset-0', 'key1'));
+        assert.equal('Ключ2-БрендированиеTR', BEM.I18N('i-keyset-0', 'key2'));
+        assert.equal('Ключ3', BEM.I18N('i-keyset-0', 'key3'));
+
+        BEM.I18N.brand('brand', null);
+        assert.equal('Ключ1', BEM.I18N('i-keyset-0', 'key1'));
+        assert.equal('', BEM.I18N('i-keyset-0', 'key3'));
+    });
+
+});


### PR DESCRIPTION
Поддержка множества ключей в декларации BEM.I18N.decl
Понадобилось в работе, для брендирования локализаций

позволяет декларировать сущности типа 

``` javascript
BEM.I18N.decl('b-keyset', {
    'key1': 'key1'
}, {lang: 'ru', brand: 'ua'})
```

при сборке нужно задавать BEM_I18N_KEYS, чтобы нужные декларации включились.

для удобного использования нужно на уровне добавить
i-bem/__i18n/i-bem__i18n.i18n/
где добавить в core.js

``` javascript
 bem_.I18N.brand = (function () {
  var klass = function (brand) {
       bem_.I18N.setDeclProp('brand', brand);
   };
   return klass;
})();
```

либо на прямую - BEM.I18N.setDeclProp(name, value);
для установки порядка ключей BEM.I18N.setOrderProps('lang', 'brand', etc)

Если решение подойдет - напишу документацию по-подробее
