### PR TITLE
i-bem: Fixed wrong regexp matching issue in `_buildModValRE`

### DIFF
--- a/blocks-common/i-bem/__dom/i-bem__dom.js
+++ b/blocks-common/i-bem/__dom/i-bem__dom.js
@@ -1602,7 +1602,7 @@ var DOM = BEM.DOM = BEM.decl('i-bem__dom',/** @lends BEM.DOM.prototype */{
      */
     _buildModValRE : function(modName, elem, quantifiers) {
 
-        return new RegExp('(\\s?)' + this._buildModClassPrefix(modName, elem) + '(' + NAME_PATTERN + ')(\\s|$)', quantifiers);
+        return new RegExp('(\\s|^)' + this._buildModClassPrefix(modName, elem) + '(' + NAME_PATTERN + ')(\\s|$)', quantifiers);
 
     },
 


### PR DESCRIPTION
Regexp:

``` javascript
/(\s?)dropdown_js_([a-zA-Z0-9-]+)(\s|$)/
```

matches `share-dropdown_js_inited` and `dropdown_js_inited` that is wrong.

/cc @dfilatov @toivonen 
