### PR TITLE
IE8 Баг с событием window.resize

### DIFF
--- a/blocks-common/i-bem/__dom/i-bem__dom.js
+++ b/blocks-common/i-bem/__dom/i-bem__dom.js
@@ -444,6 +444,34 @@ var DOM = BEM.DOM = BEM.decl('i-bem__dom',/** @lends BEM.DOM.prototype */{
      */
     bindToWin : function(event, fn) {
 
+        var _fn = fn,
+            currentHeight,
+            currentWidth,
+            win;
+
+        if (event === 'resize') {
+
+            win = $(window);
+
+            fn = function() {
+
+                var height = win.height(),
+                    width = win.width();
+
+                if (currentHeight !== height || currentWidth !== width) {
+
+                    currentHeight = height;
+                    currentWidth = width;
+
+                    _fn.apply(this, arguments);
+
+                }
+
+
+            }
+
+        }
+
         this._needSpecialUnbind = true;
         return this.bindToDomElem(win, event, fn);
 

--- a/blocks-common/i-bem/__dom/i-bem__dom.js
+++ b/blocks-common/i-bem/__dom/i-bem__dom.js
@@ -451,7 +451,7 @@ var DOM = BEM.DOM = BEM.decl('i-bem__dom',/** @lends BEM.DOM.prototype */{
 
         if (event === 'resize') {
 
-            win = $(window);
+            win = this.__self.win;
 
             fn = function() {
 


### PR DESCRIPTION
IE8 триггерит resize окна при изменении размеров любого элемента, иногда это может привести к неожиданным результатам
http://cyanbyfuchsia.wordpress.com/2012/06/20/window-resize-and-internet-explorer-8/
