### PR TITLE
Fix mod-val regexp: method `getMods` didn't return all mods

### DIFF
--- a/blocks-common/i-bem/__dom/i-bem__dom.js
+++ b/blocks-common/i-bem/__dom/i-bem__dom.js
@@ -1602,7 +1602,7 @@ var DOM = BEM.DOM = BEM.decl('i-bem__dom',/** @lends BEM.DOM.prototype */{
      */
     _buildModValRE : function(modName, elem, quantifiers) {
 
-        return new RegExp('(\\s|^)' + this._buildModClassPrefix(modName, elem) + '(' + NAME_PATTERN + ')(\\s|$)', quantifiers);
+        return new RegExp('(\\s|^)' + this._buildModClassPrefix(modName, elem) + '(' + NAME_PATTERN + ')(?=\\s|$)', quantifiers);
 
     },
 


### PR DESCRIPTION
Old regexp didn't match a block (elem) modifications which were fallowed one-by-one:
`b-test_mod-1_val b-test_mod-2_val b-test_mod-3_val b-test_mod-4_val b-test_mod-5_val`
for such className value was matched:
`["b-test_mod-1_val ", " b-test_mod-3_val ", " b-test_mod-5_val"]`
but classes `b-test_mod-2_val` and `b-test_mod-4_val` weren't matched.
