### PR TITLE
Make i18n.js.js use source suffixes of base js tech

### DIFF
--- a/blocks-common/i-bem/bem/techs/v2/i18n.js.js
+++ b/blocks-common/i-bem/bem/techs/v2/i18n.js.js
@@ -14,12 +14,13 @@ exports.techMixin = BEM.util.extend({}, LangsMixin, {
 
     getBuildSuffixesMap: function() {
 
-        var suffixes = {};
+        var suffixes = {},
+            baseSuffixes = this.__base()[this.getBaseTechSuffx()] || [this.getBaseTechSuffix];
 
         this.getLangs()
             .map(this.getBuildSuffixForLang, this).concat([this.getBaseTechSuffix()])
             .forEach(function(s) {
-                suffixes[s] = [this.getBaseTechSuffix()];
+                suffixes[s] = baseSuffixes;
             }, this);
 
         return suffixes;


### PR DESCRIPTION
Make i18n.js.js use source suffixes of base js tech so it will work when base js uses more source suffixes (js+coffee for example).
