### PR TITLE
i-bem__html: Фикс обработки массива с элементом undefined

### DIFF
--- a/blocks-common/i-bem/__html/i-bem__html.bemhtml
+++ b/blocks-common/i-bem/__html/i-bem__html.bemhtml
@@ -303,7 +303,7 @@ this._mode === '' {
 
         while(i < l) {
             var newCtx = v[i++];
-            apply(this.ctx = newCtx === null ? '' : newCtx);
+            apply(this.ctx = newCtx == null ? '' : newCtx);
         }
 
         prevNotNewList || (this.position = prevPos);


### PR DESCRIPTION
Фикс следующей проблемы.

При обработке вот такого bemjson'а:

``` javascript
{
    block: 'b-link',
    content: [ undefined ]
}
```

вот таким вот правилом:

```
block b-link, this.ctx.url, tag: 'a'
```

(взято из https://github.com/bem/bem-bl/blob/0.3/blocks-touch/b-link/b-link.bemhtml#L17)

происходит ошибка:

```
if(!!this.elem === false && this.block === "b-link" && !this.ctx.url === false
                                                                ^
TypeError: Cannot read property 'url' of undefined
```
