### PR TITLE
Introspection availability in inheritance is minification-proof now

### DIFF
--- a/blocks-common/i-jquery/__inherit/i-jquery__inherit.js
+++ b/blocks-common/i-jquery/__inherit/i-jquery__inherit.js
@@ -11,7 +11,7 @@
 
 (function($) {
 
-var hasIntrospection = (function(){_}).toString().indexOf('_') > -1,
+var hasIntrospection = (function(){'_';}).toString().indexOf('_') > -1,
     emptyBase = function() {},
     objCreate = Object.create || function(ptp) {
         var inheritance = function() {};


### PR DESCRIPTION
В актуальной на данный момент версии `bem-bl` используется версия 1.3.5 плагина `Inheritance` (см. https://github.com/bem/bem-bl/blob/0.3.19/blocks-common/i-jquery/__inherit/i-jquery__inherit.js)

Эта версия содержит баг, появляющийся при минификации. Суть бага такова:

```
...
var hasIntrospection = (function(){_}).toString().indexOf('_') > -1,
...
```

После работы минификатора переменная `_` удаляется из тела анонимной функции как неиспользуемая и флаг `hasIntrospection`  всегда принимает значение `false`. Этот баг устранен в актуальной версии `Inheritance` 2.1.0 (см. https://github.com/dfilatov/inherit/blob/master/lib/inherit.js)
