### PR TITLE
fix npm-shrinkwrap - remove resolved lines

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5,52 +5,42 @@
     "xjst": {
       "version": "0.5.15",
       "from": "xjst@~0.5.1",
-      "resolved": "http://registry.npmjs.org/xjst/-/xjst-0.5.15.tgz",
       "dependencies": {
         "coa": {
           "version": "0.3.9",
-          "from": "coa@0.3.x",
-          "resolved": "http://registry.npmjs.org/coa/-/coa-0.3.9.tgz"
+          "from": "coa@0.3.x"
         },
         "q": {
           "version": "0.8.12",
-          "from": "q@0.8.x",
-          "resolved": "http://registry.npmjs.org/q/-/q-0.8.12.tgz"
+          "from": "q@0.8.x"
         },
         "uglify-js": {
           "version": "1.3.5",
-          "from": "uglify-js@1.3.x",
-          "resolved": "http://registry.npmjs.org/uglify-js/-/uglify-js-1.3.5.tgz"
+          "from": "uglify-js@1.3.x"
         },
         "spoon": {
           "version": "0.1.10",
           "from": "spoon@~0.1.10",
-          "resolved": "http://registry.npmjs.org/spoon/-/spoon-0.1.10.tgz",
           "dependencies": {
             "esprima": {
               "version": "1.0.4",
-              "from": "esprima@~1.0.2",
-              "resolved": "http://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+              "from": "esprima@~1.0.2"
             },
             "escodegen": {
               "version": "0.0.27",
               "from": "escodegen@~0.0.15",
-              "resolved": "http://registry.npmjs.org/escodegen/-/escodegen-0.0.27.tgz",
               "dependencies": {
                 "estraverse": {
                   "version": "1.3.1",
-                  "from": "estraverse@~1.3.0",
-                  "resolved": "http://registry.npmjs.org/estraverse/-/estraverse-1.3.1.tgz"
+                  "from": "estraverse@~1.3.0"
                 },
                 "source-map": {
                   "version": "0.1.30",
                   "from": "source-map@>= 0.1.2",
-                  "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.1.30.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "0.0.8",
-                      "from": "amdefine@>=0.0.4",
-                      "resolved": "http://registry.npmjs.org/amdefine/-/amdefine-0.0.8.tgz"
+                      "from": "amdefine@>=0.0.4"
                     }
                   }
                 }
@@ -58,8 +48,7 @@
             },
             "estraverse": {
               "version": "0.0.4",
-              "from": "estraverse@~0.0.4",
-              "resolved": "http://registry.npmjs.org/estraverse/-/estraverse-0.0.4.tgz"
+              "from": "estraverse@~0.0.4"
             }
           }
         }
@@ -68,34 +57,28 @@
     "ometajs": {
       "version": "3.2.4",
       "from": "ometajs@~3.2.2",
-      "resolved": "http://registry.npmjs.org/ometajs/-/ometajs-3.2.4.tgz",
       "dependencies": {
         "coa": {
           "version": "0.3.9",
-          "from": "coa@0.3.x",
-          "resolved": "http://registry.npmjs.org/coa/-/coa-0.3.9.tgz"
+          "from": "coa@0.3.x"
         },
         "q": {
           "version": "0.8.12",
-          "from": "q@0.8.x",
-          "resolved": "http://registry.npmjs.org/q/-/q-0.8.12.tgz"
+          "from": "q@0.8.x"
         },
         "uglify-js": {
           "version": "1.3.5",
-          "from": "uglify-js@1.3.x",
-          "resolved": "http://registry.npmjs.org/uglify-js/-/uglify-js-1.3.5.tgz"
+          "from": "uglify-js@1.3.x"
         }
       }
     },
     "dom-js": {
       "version": "0.0.9",
       "from": "dom-js@~0.0.9",
-      "resolved": "http://registry.npmjs.org/dom-js/-/dom-js-0.0.9.tgz",
       "dependencies": {
         "sax": {
           "version": "0.5.5",
-          "from": "sax@>=0.1.5",
-          "resolved": "http://registry.npmjs.org/sax/-/sax-0.5.5.tgz"
+          "from": "sax@>=0.1.5"
         }
       }
     }


### PR DESCRIPTION
In the npm-shrinkwrap.json file there shouldn't be fields "resolved" with links to the register. 
Because of them it is impossible to tell npm that libraries need to be put from other storage, instead of from the official register (which now lies ;)
