### PR TITLE
Fix empty keys compilation for i18n's processing

### DIFF
--- a/blocks-common/i-bem/__i18n/lib/tanker.js
+++ b/blocks-common/i-bem/__i18n/lib/tanker.js
@@ -1,10 +1,7 @@
 var DOM = require('dom-js'),
-
     QUOTE_CHAR = '"',
     SINGLE_QUOTE_CHAR = "'",
-
     isArray = Array.isArray,
-
     isJson = function(obj) {
         try {
             if(isString(obj)) {
@@ -25,7 +22,6 @@ var DOM = require('dom-js'),
         return type === 'string' || type === 'number';
     };
 
-
 var parseXml = exports.parseXml = function(xml, cb) {
 
         isSimple(xml) || (xml = JSON.stringify(xml));
@@ -43,6 +39,10 @@ var parseXml = exports.parseXml = function(xml, cb) {
     domToJs = exports.domToJs = function(nodes) {
 
         var code = expandNodes(toCommonNodes(nodes), jsExpander);
+
+        if(!code.length) {
+            return '\'\'';
+        }
 
         return code.length === 1 &&
             (code[0].charAt(0) === QUOTE_CHAR || code[0].charAt(0) === SINGLE_QUOTE_CHAR ) ?

--- a/blocks-common/i-bem/__i18n/test/test-js-parser.js
+++ b/blocks-common/i-bem/__i18n/test/test-js-parser.js
@@ -1,15 +1,12 @@
 var ASSERT = require('assert'),
     PATH = require('path'),
     FS = require('fs'),
-
     inspect = require('util').inspect,
-
     PARSER = require('../lib/tanker.js');
 
 function readFile(src) {
     return FS.readFileSync(PATH.resolve(__dirname, 'files', src), 'utf-8').toString();
 }
-
 
 function unit(name) {
     var content = {
@@ -39,3 +36,4 @@ unit('literal-01');
 unit('literal-02');
 unit('literal-03');
 unit('json-01');
+unit('empty-01');


### PR DESCRIPTION
Right now empty keys, e.g. `""` are translated to JS code

``` javascript
function() { return; }
```

which is not correct.
