### PR TITLE
[touch] i-ua: Не работает проверка на wp для Nokia Lumia

### DIFF
--- a/blocks-touch/i-ua/i-ua.js
+++ b/blocks-touch/i-ua/i-ua.js
@@ -21,7 +21,7 @@
         device.ipad = true;
     } else if (match = ua.match(/Bada\/([\d.]+)/)) {
         platform.bada = match[1];
-    } else if (match = ua.match(/Windows\sPhone.*\s([\d.]+)/)) {
+    } else if (match = ua.match(/Windows\sPhone[^\d]*\s([\d.]+)/)) {
         platform.wp = match[1];
     } else {
         platform.other = true;


### PR DESCRIPTION
После https://github.com/bem/bem-bl/pull/327 для NOKIA Lumia 800 c useragent'ом:
Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; NOKIA; Lumia 800)
некорректно срабатывает регулярка, и версия wp становится 800.

До этого проверяли wp7 useragent'ом:
Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; SAMSUNG; SGH-i917)
и тогда, понятно, что работало.
