### PR TITLE
Возникает исключение, в случае, если у блока нет DOM элемента

### DIFF
--- a/blocks-common/i-bem/__dom/i-bem__dom.js
+++ b/blocks-common/i-bem/__dom/i-bem__dom.js
@@ -390,7 +390,13 @@ var DOM = BEM.DOM = BEM.decl('i-bem__dom',/** @lends BEM.DOM.prototype */{
                     buildClass(blockName) :
                     buildClass(blockName, block.modName, block.modVal)) +
                 (onlyFirst? ':first' : ''),
-            domElems = ctxElem.filter(selector);
+        domElems;
+
+        if (!ctxElem) {
+            return [];
+        }
+
+        domElems = ctxElem.filter(selector);
 
         select && (domElems = domElems.add(ctxElem[select](selector)));
 


### PR DESCRIPTION
Ошибка возникает когда при событии происходит удаление дом элемента блока. А _liveInitOnBlockEvent срабатывает после того как элемент был удален.
