### PR TITLE
Added `applyFuncName` option to bemhtml translator

### DIFF
--- a/blocks-common/i-bem/__html/lib/bemhtml/api.js
+++ b/blocks-common/i-bem/__html/lib/bemhtml/api.js
@@ -40,6 +40,7 @@ api.translate = function translate(source, options) {
 
   options || (options = {});
   options.exportName || (options.exportName = 'BEMHTML');
+  options.applyFuncName || (options.applyFuncName = 'apply');
 
   if (options.cache === true) {
     var xjstCached = BEMHTMLLogLocal.match(xjstPre, 'topLevel');
@@ -82,7 +83,7 @@ api.translate = function translate(source, options) {
                   }).join('') +
          '      }\n' +
          (vars.length > 0 ? '    var ' + vars.join(', ') + ';\n' : '') +
-         '      return xjst.apply.call(\n' +
+         '      return xjst.' + options.applyFuncName + '.call(\n' +
          (options.raw ? 'context' : '[context]') + '\n' +
          '      );\n' +
          '    }.call(null);\n' +


### PR DESCRIPTION
Instead of #446 

This allows to use different templates, such as for `bemtree` and other.
For example, see https://github.com/narqo/bem-yana-stub/blob/master/common.blocks/i-bem/i-bem.bemtree.xjst#L102

Also we can use bemhtml translator from `bem-bl` in `enb-bemhtml` as-is.
