### PR TITLE
bemhtml: introduce tree structure checks

### DIFF
--- a/blocks-common/i-bem/__html/lib/bemhtml/api.js
+++ b/blocks-common/i-bem/__html/lib/bemhtml/api.js
@@ -5,6 +5,7 @@ var ometajs = require('ometajs'),
     xjst = require('xjst'),
     vm = require('vm'),
     bemhtml = require('../ometa/bemhtml'),
+    checks = require('./checks'),
     BEMHTMLParser = bemhtml.BEMHTMLParser,
     BEMHTMLToXJST = bemhtml.BEMHTMLToXJST,
     BEMHTMLLogLocal = bemhtml.BEMHTMLLogLocal;
@@ -53,7 +54,24 @@ api.translate = function translate(source, options) {
   try {
     var xjstJS = xjst.compile(xjstTree, '', {
       'no-opt': !!options.devMode,
-      engine: 'sort-group'
+      engine: 'sort-group',
+      afterCompile: function(tree) {
+        if (options.nochecks)
+          return;
+
+        var errors = [];
+
+        errors = errors.concat(checks.treeStructure(tree));
+
+        if (errors.length) {
+          var red = '\x1b[1;31m';
+          var rst = '\x1b[0m';
+          console.error(red + '!!! WARNING !!!!');
+          for (var i = 0; i < errors.length; i++)
+            console.error(errors[i]);
+          console.error('!!! WARNING !!!!' + rst);
+        }
+      }
     });
   } catch (e) {
     throw new Error("xjst to js compilation failed:\n" + e.stack);

--- a/blocks-common/i-bem/__html/lib/bemhtml/checks.js
+++ b/blocks-common/i-bem/__html/lib/bemhtml/checks.js
@@ -1,0 +1,19 @@
+var checks = exports;
+
+checks.treeStructure = function treeStructure(tree) {
+  var errors = [];
+  if (tree.tagStr !== '["getp",["string","_mode"],["get","__$ctx"]]') {
+    errors.push('Top node does not contain `_mode`, looks like one of ' +
+                'templates is missing a `_mode` predicate!');
+  }
+  var depth = 0;
+  for (var current = tree; tree; tree = tree['default']) {
+    depth++;
+  }
+  if (depth > 5) {
+    errors.push('Seems like a predicate tree contains some irregularities. ' +
+                'Please verify that `_mode` predicate is present everywhere');
+  }
+
+  return errors;
+};

--- a/blocks-common/i-bem/__html/test/basic-test.js
+++ b/blocks-common/i-bem/__html/test/basic-test.js
@@ -10,7 +10,10 @@ suite('BEMHTML Compiler', function() {
 
   function unit(name, src, data, dst) {
     test(name, function() {
-      assert.equal(bemhtml.compile(src, { raw: true }).call(data), dst);
+      assert.equal(bemhtml.compile(src, {
+        raw: true,
+        nochecks: true
+      }).call(data), dst);
     });
   }
 

--- a/blocks-common/i-bem/__html/test/files/i-bem/gh-239.bemhtml
+++ b/blocks-common/i-bem/__html/test/files/i-bem/gh-239.bemhtml
@@ -1,3 +1,3 @@
-block para, this.elem === 'cell' || this.elem === 'gap': {
+content, block para, this.elem === 'cell' || this.elem === 'gap': {
   return 'hello';
 }

--- a/blocks-common/i-bem/__html/test/files/i-bem/local-var.bemhtml
+++ b/blocks-common/i-bem/__html/test/files/i-bem/local-var.bemhtml
@@ -1,4 +1,4 @@
-block b1 {
+this._mode === '', block b1 {
   true: {
     var x;
     if (x !== undefined) throw new Error('x should not change');
@@ -8,7 +8,7 @@ block b1 {
   tag: 'div'
 }
 
-block b2 {
+this._mode === '', block b2 {
   true: {
     var x;
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "xjst": "~0.5.1",
+    "xjst": "~0.5.19",
     "ometajs": "~3.3.5",
     "dom-js": "~0.0.9",
     "estraverse": "~1.5.0",


### PR DESCRIPTION
n/t

We have a lot of problems with a missing _mode predicate in some of the templates. When it is not present - whole tree structure of the compiled bemhtml.js becomes wrong and very slow. This patch will print warning in case of getting oddly-shaped tree after compilation.
