### PR TITLE
Check for block#destruct() has been called already

### DIFF
--- a/blocks-common/i-bem/__dom/i-bem__dom.js
+++ b/blocks-common/i-bem/__dom/i-bem__dom.js
@@ -949,6 +949,8 @@ var DOM = BEM.DOM = BEM.decl('i-bem__dom', {
         var _this = this,
             _self = _this.__self;
 
+        if(_this._isDestructing) return;
+
         _this._isDestructing = true;
 
         _this._needSpecialUnbind && _self.doc.add(_self.win).unbind('.' + _this._uniqId);


### PR DESCRIPTION
Fix for "TypeError: 'undefined' is not an object evaluating '_this.dropElemCache().domElem.each'" if `block#destruct()` has been called several times.

The problem could occur after #508. There may be a situation when one **needs to** call nested block's `destruct` during destruction process.

\cc @dfilatov 
