### PR TITLE
ISLCOMPONENTS-1273 — textarea/select disabled: На планшетах срабатывает тап

### DIFF
--- a/blocks-touch/i-fastclick/i-fastclick.js
+++ b/blocks-touch/i-fastclick/i-fastclick.js
@@ -229,6 +229,12 @@ FastClick.prototype.needsClick = function(target) {
  */
 FastClick.prototype.needsFocus = function(target) {
     'use strict';
+    // No point in attempting to focus disabled elements
+    // bem-bl https://github.com/ftlabs/fastclick/issues/285
+    if(target.disabled || target.readOnly){
+        return false;
+    };
+
     switch (target.nodeName.toLowerCase()) {
     case 'textarea':
         return true;
@@ -245,8 +251,7 @@ FastClick.prototype.needsFocus = function(target) {
             return false;
         }
 
-        // No point in attempting to focus disabled inputs
-        return !target.disabled && !target.readOnly;
+        return true;
     default:
         return (/\bneedsfocus\b/).test(target.className);
     }


### PR DESCRIPTION
Из-за needFocus возвращающего true генерируется синтетический клик без проверки https://github.com/ftlabs/fastclick/blob/master/lib/fastclick.js#L213
