### PR TITLE
BEM-1806 — i-pointer-events: Лишний раз инициируется событие pointerdown

### DIFF
--- a/blocks-touch/i-pointer-events/i-pointer-events.js
+++ b/blocks-touch/i-pointer-events/i-pointer-events.js
@@ -464,6 +464,11 @@
     function applySimpleEventTunnels(nameGenerator, eventGenerator) {
         ["pointerdown", "pointermove", "pointerup", "pointerover", "pointerout"].forEach(function (eventName) {
             window.addEventListener(nameGenerator(eventName), function (evt) {
+                // bem-bl prevent second pointerdown, because our i-fastclick triggers synthetic mousedown before click
+                if(evt.forwardedTouchEvent) {
+                    return;
+                }
+
                 if (!touching && findEventRegisteredNode(evt.target, eventName))
                     eventGenerator(evt, eventName, true);
             });


### PR DESCRIPTION
в целом ситуация такая - первый раз pointerdown триггерится по touchstart, все ок, но когда мы в fastclick синтетически генерируем mousedown, pointer-events генерит нам pointerdown второй раз. в целом необходимо, чтобы при таких вот синтетических событиях pointer-\* библиотека не генерировала событие, самый дешевый по производительности способ это проверить наличие флага, который сейчас выставляется в i-fastclick. 
по идее надо выпилить как только перейдем на реализацию pointer-events из bem-core или прекратим генерировать синтетиеский mousedown в fastclick для обратной совместимости
