### PR TITLE
Allow non-array mixes

### DIFF
--- a/blocks-common/i-bem/__html/i-bem__html.bemhtml
+++ b/blocks-common/i-bem/__html/i-bem__html.bemhtml
@@ -351,7 +351,7 @@ default: {
                 BEM_.INTERNAL.buildClasses(this.block, v.elem, v.elemMods || v.mods, buf);
 
                 var mix = apply(this._mode = 'mix');
-                v.mix && (mix = mix? mix.concat(v.mix) : v.mix);
+                v.mix && (mix = mix? [].concat(mix, v.mix) : v.mix);
 
                 if(mix) {
                     var visited = {};


### PR DESCRIPTION
BEMJSON: `{ block: 'foo', mix: { block: 'bar' } }`
BEMHTML: `block foo, mix: { block: 'foobar' }`
Result: `TypeError: Object #<Object> has no method 'concat'`
Expected: `<div class="foo bar foobar"></div>`

Correct solution:
https://github.com/bem/bem-core/blob/a5efc85cb/common.blocks/i-bem/i-bem.bemhtml#L360
