### PR TITLE
Удаляем ненужный кусок текста с неработающими ссылками

### DIFF
--- a/blocks-common/i-bem/i-bem.ru.md
+++ b/blocks-common/i-bem/i-bem.ru.md
@@ -728,8 +728,6 @@ BEM.DOM.decl('b-my-block', {
 * `findBlockOn/findBlocksOn` — поиск блока/блоков на `DOM`-элементах текущего блока или его элементов;
 * `findBlockOutside/findBlocksOutside` — поиск блока/блоков снаружи `DOM`-элементов текущего блока или его элементов.
 
-Примерами блоков, использующих методы поиска других блоков, могут быть: [b-smart-help](/blocks/b-smart-help/b-smart-help.md), [b-screenshot](blocks/b-screenshot/b-screenshot.md) и [b-dropdowna](blocks/b-dropdowna/b-dropdowna.md).
-
 #### Методы доступа к элементам
 Для поиска элементов внутри блока используется метод `elem`. Результат этого метода кэшируется.
 


### PR DESCRIPTION
Вот в этом разделе https://github.com/bem/bem-bl/blob/dev/blocks-common/i-bem/i-bem.ru.md#%D0%9C%D0%B5%D1%82%D0%BE%D0%B4%D1%8B-%D0%BF%D0%BE%D0%B8%D1%81%D0%BA%D0%B0-%D0%B1%D0%BB%D0%BE%D0%BA%D0%BE%D0%B2 есть ссылки на внутренние блоки, которые все равно неверные.
