### PR TITLE
HiDPI detection improvement

### DIFF
--- a/blocks-common/i-ua/i-ua.js
+++ b/blocks-common/i-ua/i-ua.js
@@ -14,9 +14,11 @@
     if (typeof win.matchMedia === 'function') {
         // In fact, HiDPI begins from 1.3dppx.
         // There is a devices list for example: http://bjango.com/articles/min-device-pixel-ratio/
-        // 124dpi ~ 1.3dppx
+        // 124dpi (used for IE) ~ 1.3dppx for now,
+        // but by standard 'dpi' means dots-per-CSS-inch, not dots-per-physical-inch
         var hiDpiQuery =
             'only screen and (-webkit-min-device-pixel-ratio: 1.3), ' +
+            'only screen and (min-resolution: 1.3dppx), ' +
             'only screen and (min-resolution: 124dpi)';
         isHiDpi = win.matchMedia(hiDpiQuery).matches;
     } else {


### PR DESCRIPTION
There is a warning in the browsers' JS console:

```
Consider using 'dppx' units, as in CSS 'dpi' means dots-per-CSS-inch, not dots-per-physical-inch, so does not correspond to the actual 'dpi' of a screen. In media query expression: only screen and (-webkit-min-device-pixel-ratio: 1.3), only screen and (min-resolution: 124dpi)
```

There is a fix of this defect.
