### PR TITLE
Non DOM blocks destruction

### DIFF
--- a/blocks-common/i-bem/i-bem.js
+++ b/blocks-common/i-bem/i-bem.js
@@ -507,7 +507,9 @@ this.BEM = $.inherit($.observable, /** @lends i-bem.prototype */ {
     /**
      * Deletes a block
      */
-    destruct : function() {}
+    destruct : function() {
+        this.un();
+    }
 
 }, /** @lends i-bem */{
 


### PR DESCRIPTION
There are hanged event listeners on non DOM blocks after `instance.destruct()`. This PR should fix this.
