### PR TITLE
b-menu-vert: Fix dependency order

### DIFF
--- a/blocks-desktop/b-menu-vert/b-menu-vert.deps.js
+++ b/blocks-desktop/b-menu-vert/b-menu-vert.deps.js
@@ -1,7 +1,9 @@
 ({
     mustDeps: [
-        { elem: 'title' },
-        { elem: 'item-content' },
         { block: 'i-menu' }
+    ],
+    shouldDeps: [
+        { elem: 'title' },
+        { elem: 'item-content' }
     ]
 })


### PR DESCRIPTION
In a case of using a custom technology, the template of the title element is not applied because of its element place in the dependency tree before the i-bem block.
