### PR TITLE
i-ua: Fix double i-ua mixin to b-page__body on touch level.

### DIFF
--- a/blocks-touch/b-page/b-page.bemhtml
+++ b/blocks-touch/b-page/b-page.bemhtml
@@ -51,13 +51,7 @@ block b-page {
                     },
                     {
                         elem: 'body',
-                        mix: [
-                            this.ctx,
-                            {
-                                block: 'i-ua',
-                                js: true
-                            }
-                        ].concat(this.ctx.mix || []),
+                        mix: [this.ctx].concat(this.ctx.mix || []),
                         content: this.ctx.content
                     }
                 ]


### PR DESCRIPTION
**It's not a bug**.
We figured out the issue: there isn't bem-bl's bug:
we have mix.push({block: 'i-ua', mods: {interaction: 'yes'}) in our level and, I didn't know about it – in mixing bemhtml set classes i-ua_interaction_yes and i-ua as well.
