### PR TITLE
No block should depend with `mustDeps` on i-jquery

### DIFF
--- a/blocks-common/i-bem/__html/i-bem__html.deps.js
+++ b/blocks-common/i-bem/__html/i-bem__html.deps.js
@@ -1,6 +1,5 @@
 ({
     mustDeps: [
-        { block: 'i-bem' },
-        { block: 'i-jquery' }
+        { block: 'i-bem' }
     ]
 })

--- a/blocks-common/i-bem/i-bem.deps.js
+++ b/blocks-common/i-bem/i-bem.deps.js
@@ -1,15 +1,10 @@
 ({
     mustDeps: [
-        {
-            block: 'i-jquery',
-            elems: [
-                'inherit',
-                'identify',
-                'is-empty-object',
-                'debounce',
-                'observable'
-            ]
-        }
+        {block: 'i-jquery', elem: 'inherit'},
+        {block: 'i-jquery', elem: 'identify'},
+        {block: 'i-jquery', elem: 'is-empty-object'},
+        {block: 'i-jquery', elem: 'debounce'},
+        {block: 'i-jquery', elem: 'observable'}
     ],
     shouldDeps: [
         { block: 'i-ecma', elem: 'object' },

--- a/blocks-desktop/b-link/_pseudo/b-link_pseudo.deps.js
+++ b/blocks-desktop/b-link/_pseudo/b-link_pseudo.deps.js
@@ -1,6 +1,6 @@
 ({
     mustDeps: [
-        { block: 'i-jquery', elems: 'leftclick' }
+        { block: 'i-jquery', elem: 'leftclick' }
     ],
     shouldDeps: [
         { mods: { pseudo: ['yes', 'no']} }

--- a/blocks-touch/b-slider/b-slider.deps.js
+++ b/blocks-touch/b-slider/b-slider.deps.js
@@ -1,9 +1,7 @@
 ({
     mustDeps: [{
         block: 'i-jquery',
-        elems: [
-            'css-prefix'
-        ]
+        elem: 'css-prefix'
     },{
         block: 'b-menu',
         mods: {


### PR DESCRIPTION
`i-jquery` is just a template - so there is no reason to specify it
in `mustDeps`, jQuery code itself won't be included before the said
block in built file.

Such dependences result in `mustDeps` cycle that can not be resolved,
so, depending on a deps tech we either get an error, or some build file
that can be build correctly or not depending on a moon phase and luck
stat of the programmer.

/cc @tadatuta @arikon 
