### PR TITLE
i-bem__dom: проверять, не уничтожен ли блок

### DIFF
--- a/blocks-common/i-bem/__dom/i-bem__dom.js
+++ b/blocks-common/i-bem/__dom/i-bem__dom.js
@@ -764,6 +764,7 @@ var DOM = BEM.DOM = BEM.decl('i-bem__dom', {
      * @param {String} [elemName] Element name
      */
     _afterSetMod : function(modName, modVal, oldModVal, elem, elemName) {
+        if (this._isDestructing) return;
 
         var _self = this.__self,
             classPrefix = _self._buildModClassPrefix(modName, elemName),


### PR DESCRIPTION
Due to syncronous modification change handlers execution `_afterSetMod` could be called after block destruction.

See https://github.com/bem/bem-bl/blob/support/2.x/blocks-common/i-bem/i-bem.js#L345,L351

Test case:

``` js
BEM.DOM.decl('kamikadze', {
    onSetMod: {
        js: {
            inited: function () {
                BEM.DOM.destruct(this.domElem);
            }
        }
    }
});

BEM.DOM.append('body', bh.apply({ block: 'kamikadze', js: true }));
```
