### PR TITLE
i-bem: use resetApplyNext before entering `content`

### DIFF
--- a/blocks-common/i-bem/__html/i-bem__html.bemhtml
+++ b/blocks-common/i-bem/__html/i-bem__html.bemhtml
@@ -472,6 +472,7 @@ default: {
         var content = apply(this._mode = 'content');
         if(content || content === 0) {
             var isBEM = this.block || this.elem;
+            resetApplyNext();
             apply(
                 this._notNewList = false,
                 this.position = isBEM ? 1 : this.position,

--- a/blocks-desktop/b-page/b-page.bemhtml
+++ b/blocks-desktop/b-page/b-page.bemhtml
@@ -7,49 +7,51 @@ block b-page {
         attrs: { 'http-equiv': 'X-UA-Compatible', content: this.ctx['x-ua-compatible'] || 'IE=edge' }
     }
 
-    default: {
-        var ctx = this.ctx,
-            dtype = apply('doctype'),
-            xUA = apply('xUACompatible'),
-            buf = [
-                dtype,
-                {
-                    elem: 'root',
-                    content: [
-                        {
-                            elem: 'head',
-                            content: [
-                                ctx.csp && this.extend(ctx.csp, { elem: 'csp' }),
-                                {
-                                    tag: 'meta',
-                                    attrs: { charset: 'utf-8' }
-                                },
-                                xUA,
-                                {
-                                    tag: 'title',
-                                    content: ctx.title
-                                },
-                                ctx.favicon ? {
-                                    elem: 'favicon',
-                                    url: ctx.favicon
-                                } : '',
-                                ctx.meta,
-                                {
-                                    block: 'i-ua',
-                                    attrs: { nonce: ctx.nonce }
-                                },
-                                ctx.head
-                            ]
-                        },
-                        ctx
-                    ]
-                }
-            ];
+    default, !this._pageInit: {
+        return local({ _pageInit: true })(function() {
+            var ctx = this.ctx,
+                dtype = apply('doctype'),
+                xUA = apply('xUACompatible'),
+                buf = [
+                    dtype,
+                    {
+                        elem: 'root',
+                        content: [
+                            {
+                                elem: 'head',
+                                content: [
+                                    ctx.csp && this.extend(ctx.csp, { elem: 'csp' }),
+                                    {
+                                        tag: 'meta',
+                                        attrs: { charset: 'utf-8' }
+                                    },
+                                    xUA,
+                                    {
+                                        tag: 'title',
+                                        content: ctx.title
+                                    },
+                                    ctx.favicon ? {
+                                        elem: 'favicon',
+                                        url: ctx.favicon
+                                    } : '',
+                                    ctx.meta,
+                                    {
+                                        block: 'i-ua',
+                                        attrs: { nonce: ctx.nonce }
+                                    },
+                                    ctx.head
+                                ]
+                            },
+                            ctx
+                        ]
+                    }
+                ];
 
-            // For css and js elements and i-jquery, i-ua blocks
-            this._nonce = this.ctx.nonce;
+                // For css and js elements and i-jquery, i-ua blocks
+                this._nonce = this.ctx.nonce;
 
-        applyCtx(buf);
+            applyCtx(buf);
+        });
     }
 
     tag: 'body'

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -63,8 +63,8 @@
       }
     },
     "xjst": {
-      "version": "0.10.0",
-      "from": "xjst@>=0.10.0 <0.11.0",
+      "version": "0.11.1",
+      "from": "xjst@>=0.11.1 <0.12.0",
       "dependencies": {
         "coa": {
           "version": "0.3.9",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.10.0",
   "private": true,
   "dependencies": {
-    "xjst": "~0.10.0",
+    "xjst": "~0.11.1",
     "ometajs": "~3.3.5",
     "dom-js": "~0.0.9",
     "estraverse": "~1.5.0",


### PR DESCRIPTION
Skip all `applyNext()` flags before entering the `content` to support
recursive blocks with `applyNext()` (see test).

Not sure if the branch is correct.

See: https://github.com/bem/bem-core/pull/899 for cross-reference.
