### PR TITLE
Magic around the `a` value for font-family property

### DIFF
--- a/blocks-desktop/b-icon/b-icon.css
+++ b/blocks-desktop/b-icon/b-icon.css
@@ -1,6 +1,6 @@
 .b-icon
 {
-    font: 0/0 a;
+    font: 0/0 iloveyandex;
 
     border: 0;
 


### PR DESCRIPTION
Hi!

It seems that such image replacement method became very popular. For instance, Nicolas Gallagher [wrote about it](http://nicolasgallagher.com/another-css-image-replacement-technique/).

There's some misunderstanding about `a` value for font-family property. What does it mean exactly? How browsers work with this value?

The answer is very simple: since a browser doesn't know about such  font-family's value it's always `serif` by default.

So, why `a`? Let it be `iloveyandex` for more clear idea — it can be anything you want, there's no magic around `a` :)
