### PR TITLE
Fix jsdoc for $.fn.bem params argument

### DIFF
--- a/blocks-common/i-bem/__dom/i-bem__dom.js
+++ b/blocks-common/i-bem/__dom/i-bem__dom.js
@@ -241,7 +241,7 @@ function getClientNode() {
 /**
  * Returns a block on a DOM element and initializes it if necessary
  * @param {String} blockName Block name
- * @param {Object} params Block parameters
+ * @param {Object} [params] Block parameters
  * @returns {BEM}
  */
 $.fn.bem = function(blockName, params) {


### PR DESCRIPTION
Looks like `params` argument should be marked as optional there.
